### PR TITLE
Scala 3 extends syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bsp
 *.DS_Store
 target
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.DS_Store
 target
 .idea
+/project

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ for the full list of super/subclass access combinations that are allowed by the 
 
 ## Development
 
+### ServiceLoader configuration
+
+Each rule must be included in the ServiceLoader configuration file in order to be loaded. This
+file is located in the `rules/src/main/resources/META-INF/services` directory.
+
 ### Compiling
 
 Clone the repository, `cd` into the `scalafix` directory, and start SBT:

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -8,7 +8,7 @@ lazy val scala3Version = "3.3.1"
 inThisBuild(
   List(
     organization := "bondlink",
-    version := "0.4.1",
+    version := "0.5.0",
     homepage := Some(url("https://github.com/mblink/scalafix-rules")),
     licenses := Seq(License.Apache2),
     gitPublishDir := file("/src/maven-repo"),

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -8,7 +8,7 @@ lazy val scala3Version = "3.3.1"
 inThisBuild(
   List(
     organization := "bondlink",
-    version := "0.4.0",
+    version := "0.4.1",
     homepage := Some(url("https://github.com/mblink/scalafix-rules")),
     licenses := Seq(License.Apache2),
     gitPublishDir := file("/src/maven-repo"),

--- a/scalafix/input/src/main/scala-3/fix/NoWithForExtends.scala
+++ b/scalafix/input/src/main/scala-3/fix/NoWithForExtends.scala
@@ -8,10 +8,30 @@ object NoWithForExtends {
 
   trait SuperB {}
 
+  trait SuperC {}
+
   trait ChildA extends SuperA with SuperB {}/* assert: NoWithForExtends
                               ^^^^
    The `with` keyword is unnecessary here, replace with a comma
    */
 
   trait ChildB extends SuperA, SuperB {}
+
+  trait ChildC extends SuperA with SuperB with SuperC {}/* assert: NoWithForExtends
+                              ^^^^
+  The `with` keyword is unnecessary here, replace with a comma
+  */
+
+  trait ChildD extends SuperA, SuperB, SuperC {}
+
+  trait SuperWithParamA(a: Int) {
+    val init = a
+  }
+
+  case class ChildE(a: Int) extends SuperWithParamA(a) with SuperB {}/* assert: NoWithForExtends
+                                                       ^^^^
+     The `with` keyword is unnecessary here, replace with a comma
+     */
+
+  case class ChildF(a: Int) extends SuperWithParamA(a), SuperB {}
 }

--- a/scalafix/input/src/main/scala-3/fix/NoWithForExtends.scala
+++ b/scalafix/input/src/main/scala-3/fix/NoWithForExtends.scala
@@ -1,0 +1,17 @@
+/*
+rule = NoWithForExtends
+*/
+package fix
+
+object NoWithForExtends {
+  trait SuperA {}
+
+  trait SuperB {}
+
+  trait ChildA extends SuperA with SuperB {}/* assert: NoWithForExtends
+                              ^^^^
+   The `with` keyword is unnecessary here, replace with a comma
+   */
+
+  trait ChildB extends SuperA, SuperB {}
+}

--- a/scalafix/input/src/main/scala-3/fix/NoWithForExtends.scala
+++ b/scalafix/input/src/main/scala-3/fix/NoWithForExtends.scala
@@ -34,4 +34,22 @@ object NoWithForExtends {
      */
 
   case class ChildF(a: Int) extends SuperWithParamA(a), SuperB {}
+
+  trait Outer {
+    trait ChildG extends SuperA with SuperB {}/* assert: NoWithForExtends
+                                ^^^^
+  The `with` keyword is unnecessary here, replace with a comma
+  */
+
+    trait ChildH extends SuperA, SuperB {}
+  }
+
+  trait WithParam[A] {}
+
+  trait WithParamChildA extends WithParam[SuperA with SuperB] with SuperC {}/* assert: NoWithForExtends
+                                                              ^^^^
+   The `with` keyword is unnecessary here, replace with a comma
+   */
+
+  trait WithParamChildB extends WithParam[SuperA with SuperB], SuperC {}
 }

--- a/scalafix/input/src/main/scala-3/fix/NoWithForExtends.scala
+++ b/scalafix/input/src/main/scala-3/fix/NoWithForExtends.scala
@@ -28,20 +28,30 @@ object NoWithForExtends {
     val init = a
   }
 
-  case class ChildE(a: Int) extends SuperWithParamA(a) with SuperB {}/* assert: NoWithForExtends
-                                                       ^^^^
+  case class ChildE(a: Int) extends SuperWithParamA(a)
+    // with comment
+    with SuperB {}/* assert: NoWithForExtends
+    ^^^^
      The `with` keyword is unnecessary here, replace with a comma
      */
 
-  case class ChildF(a: Int) extends SuperWithParamA(a), SuperB {}
+  case class ChildF(a: Int) extends SuperWithParamA(a),
+  // with comment
+  SuperB {}
 
-  trait Outer {
+  object Outer {
     trait ChildG extends SuperA with SuperB {}/* assert: NoWithForExtends
                                 ^^^^
   The `with` keyword is unnecessary here, replace with a comma
   */
 
     trait ChildH extends SuperA, SuperB {}
+
+    object Inner {
+      trait Core {}
+    }
+
+    trait Mantle
   }
 
   trait WithParam[A] {}
@@ -52,4 +62,11 @@ object NoWithForExtends {
    */
 
   trait WithParamChildB extends WithParam[SuperA with SuperB], SuperC {}
+
+  trait DotAccessWith extends Outer.Inner.Core with Outer.Mantle {}/* assert: NoWithForExtends
+                                               ^^^^
+  The `with` keyword is unnecessary here, replace with a comma
+  */
+
+  trait DotAccessComma extends Outer.Inner.Core, Outer.Mantle {}
 }

--- a/scalafix/output/src/main/scala-3/fix/NoWithForExtends.scala
+++ b/scalafix/output/src/main/scala-3/fix/NoWithForExtends.scala
@@ -5,7 +5,21 @@ object NoWithForExtends {
 
   trait SuperB {}
 
+  trait SuperC {}
+
   trait ChildA extends SuperA with SuperB {}
 
   trait ChildB extends SuperA, SuperB {}
+
+  trait ChildC extends SuperA with SuperB with SuperC {}
+
+  trait ChildD extends SuperA, SuperB, SuperC {}
+
+  trait SuperWithParamA(a: Int) {
+    val init = a
+  }
+
+  case class ChildE(a: Int) extends SuperWithParamA(a) with SuperB {}
+
+  case class ChildF(a: Int) extends SuperWithParamA(a), SuperB {}
 }

--- a/scalafix/output/src/main/scala-3/fix/NoWithForExtends.scala
+++ b/scalafix/output/src/main/scala-3/fix/NoWithForExtends.scala
@@ -1,0 +1,11 @@
+package fix
+
+object NoWithForExtends {
+  trait SuperA {}
+
+  trait SuperB {}
+
+  trait ChildA extends SuperA with SuperB {}
+
+  trait ChildB extends SuperA, SuperB {}
+}

--- a/scalafix/output/src/main/scala-3/fix/NoWithForExtends.scala
+++ b/scalafix/output/src/main/scala-3/fix/NoWithForExtends.scala
@@ -22,4 +22,16 @@ object NoWithForExtends {
   case class ChildE(a: Int) extends SuperWithParamA(a) with SuperB {}
 
   case class ChildF(a: Int) extends SuperWithParamA(a), SuperB {}
+
+  trait Outer {
+    trait ChildG extends SuperA with SuperB {}
+
+    trait ChildH extends SuperA, SuperB {}
+  }
+
+  trait WithParam[A] {}
+
+  trait WithParamChildA extends WithParam[SuperA with SuperB] with SuperC {}
+
+  trait WithParamChildB extends WithParam[SuperA with SuperB], SuperC {}
 }

--- a/scalafix/output/src/main/scala-3/fix/NoWithForExtends.scala
+++ b/scalafix/output/src/main/scala-3/fix/NoWithForExtends.scala
@@ -19,14 +19,24 @@ object NoWithForExtends {
     val init = a
   }
 
-  case class ChildE(a: Int) extends SuperWithParamA(a) with SuperB {}
+  case class ChildE(a: Int) extends SuperWithParamA(a)
+    // with comment
+    with SuperB {}
 
-  case class ChildF(a: Int) extends SuperWithParamA(a), SuperB {}
+  case class ChildF(a: Int) extends SuperWithParamA(a),
+  // with comment
+  SuperB {}
 
-  trait Outer {
+  object Outer {
     trait ChildG extends SuperA with SuperB {}
 
     trait ChildH extends SuperA, SuperB {}
+
+    object Inner {
+      trait Core {}
+    }
+
+    trait Mantle
   }
 
   trait WithParam[A] {}
@@ -34,4 +44,8 @@ object NoWithForExtends {
   trait WithParamChildA extends WithParam[SuperA with SuperB] with SuperC {}
 
   trait WithParamChildB extends WithParam[SuperA with SuperB], SuperC {}
+
+  trait DotAccessWith extends Outer.Inner.Core with Outer.Mantle {}
+
+  trait DotAccessComma extends Outer.Inner.Core, Outer.Mantle {}
 }

--- a/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/scalafix/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,2 +1,3 @@
 fix.NoUnnecessaryCase
 fix.StrictSubclassAccess
+fix.NoWithForExtends

--- a/scalafix/rules/src/main/scala/fix/NoWithForExtends.scala
+++ b/scalafix/rules/src/main/scala/fix/NoWithForExtends.scala
@@ -1,0 +1,24 @@
+package fix
+
+import scalafix.v1._
+
+import scala.meta._
+import scala.meta.tokens.Token.{KwWith, KwExtends}
+
+case class WithForExtends(pos: Position) extends Diagnostic {
+  override def message = "The `with` keyword is unnecessary here, replace with a comma"
+  override def position: _root_.scala.meta.Position = pos
+}
+
+class NoWithForExtends extends SyntacticRule("NoWithForExtends") {
+  @annotation.tailrec
+  private def containsSublist(list: List[Token]): Option[Token] = list match {
+    case Nil => None
+    case (_: KwExtends) :: _ :: _ :: _ :: (wth: KwWith) :: _ => Some(wth)
+    case _  :: tail => containsSublist(tail)
+  }
+
+  override def fix(implicit doc: SyntacticDocument): Patch = {
+    containsSublist(doc.tokens.toList).map(tok => Patch.lint(WithForExtends(tok.pos))).getOrElse(Patch.empty)
+  }
+}

--- a/scalafix/rules/src/main/scala/fix/NoWithForExtends.scala
+++ b/scalafix/rules/src/main/scala/fix/NoWithForExtends.scala
@@ -31,7 +31,6 @@ class NoWithForExtends extends SyntacticRule("NoWithForExtends") {
   private def containsSublist(list: List[Token]): Option[Token] = list match {
     case Nil => None
     case (_: KwExtends) :: _ :: _ :: _ :: (wth: KwWith) :: _ => Some(wth)
-    case (_: KwExtends) :: _ :: _ :: _ :: _ :: (wth: KwWith) :: _ => Some(wth)
     case _  :: tail => containsSublist(tail)
   }
 

--- a/scalafix/rules/src/main/scala/fix/NoWithForExtends.scala
+++ b/scalafix/rules/src/main/scala/fix/NoWithForExtends.scala
@@ -3,22 +3,56 @@ package fix
 import scalafix.v1._
 
 import scala.meta._
-import scala.meta.tokens.Token.{KwWith, KwExtends}
+import scala.reflect.ClassTag
+import scala.meta.tokens.Token.{KwExtends, KwWith, LeftBracket, LeftParen, RightBracket, RightParen}
 
-case class WithForExtends(pos: Position) extends Diagnostic {
+case class WithForExtends(position: Position) extends Diagnostic {
   override def message = "The `with` keyword is unnecessary here, replace with a comma"
-  override def position: _root_.scala.meta.Position = pos
 }
 
 class NoWithForExtends extends SyntacticRule("NoWithForExtends") {
+
+  private def cleanPairedTokens[L <: Token : ClassTag, R <: Token : ClassTag](tlist: List[Token]): List[Token] = {
+    @annotation.tailrec
+    def recurseWithFlag(tlist: List[Token], acc: List[Token], flag: Boolean): List[Token] = {
+      tlist match {
+        case Nil => acc
+        case (_: L) :: tail => recurseWithFlag(tail, acc, false)
+        case (_ : R) :: tail => recurseWithFlag(tail, acc, true)
+        case tok :: tail if flag => recurseWithFlag(tail, acc :+ tok, flag)
+        case _ :: tail => recurseWithFlag(tail, acc, flag)
+      }
+    }
+
+    recurseWithFlag(tlist, List(), true)
+  }
+
   @annotation.tailrec
   private def containsSublist(list: List[Token]): Option[Token] = list match {
     case Nil => None
     case (_: KwExtends) :: _ :: _ :: _ :: (wth: KwWith) :: _ => Some(wth)
+    case (_: KwExtends) :: _ :: _ :: _ :: _ :: (wth: KwWith) :: _ => Some(wth)
     case _  :: tail => containsSublist(tail)
   }
 
+  private def traverseTree(tree: Tree): List[Tokens] = {
+    val toks = tree.children.collect {
+      case t: Template if t.inits.length > 1 => t.tokens
+    }
+    tree.children.length match {
+      case  0 => toks
+      case _ => toks ++ tree.children.flatMap(c => traverseTree(c))
+    }
+  }
+
   override def fix(implicit doc: SyntacticDocument): Patch = {
-    containsSublist(doc.tokens.toList).map(tok => Patch.lint(WithForExtends(tok.pos))).getOrElse(Patch.empty)
+    println(traverseTree(doc.tree).flatMap(_.toList).map(tok => tok.text)): Unit
+    traverseTree(doc.tree)
+      .map(_.toList)
+      .map(cleanPairedTokens[LeftParen, RightParen])
+      .map(cleanPairedTokens[LeftBracket, RightBracket])
+      .map(containsSublist).collect {
+      case Some(tok) => Patch.lint(WithForExtends(tok.pos))
+    }.asPatch
   }
 }

--- a/scalafix/rules/src/main/scala/fix/NoWithForExtends.scala
+++ b/scalafix/rules/src/main/scala/fix/NoWithForExtends.scala
@@ -54,7 +54,6 @@ class NoWithForExtends extends SyntacticRule("NoWithForExtends") {
   }
 
   override def fix(implicit doc: SyntacticDocument): Patch = {
-    println(traverseTree(doc.tree).flatMap(_.toList).map(tok => tok.text)): Unit
     traverseTree(doc.tree)
       .map(_.toList)
       .map(cleanPairedTokens[LeftParen, RightParen])


### PR DESCRIPTION
Added Scalafix rule to check for usage of `extends _ with _` instead of `extends _, _`

It appears that the AST is the same regardless of whether you use `with` or `,` , so the only way I could think of to do this was by directly checking the tokens. I still want to add more test cases etc. but wanted to throw this up in case you had a better idea on how to accomplish this.