### PR TITLE
Check for unnecessary `.pure` calls in any step of a for comprehension

### DIFF
--- a/input/src/main/scala-3/fix/NoUnnecessaryPure.scala
+++ b/input/src/main/scala-3/fix/NoUnnecessaryPure.scala
@@ -13,7 +13,7 @@ object NoUnnecessaryPure {
     i <- 1.pure[Option]/* assert: NoUnnecessaryPure
          ^^^^^^^^^^^^^^
 
-The first statement of a for comprehension no longer needs to use `<-` along with `.pure`, it can use `=`
+Statements in a for comprehension do not need to use `<-` along with `.pure`, they can use `=`
 
 Before:
 
@@ -29,5 +29,23 @@ After:
     ...
   } yield result */
     j = 2
-  } yield i + j
+    k <- 3.pure[Option]/* assert: NoUnnecessaryPure
+         ^^^^^^^^^^^^^^
+
+Statements in a for comprehension do not need to use `<-` along with `.pure`, they can use `=`
+
+Before:
+
+  for {
+    x <- someStatementHere.pure[SomeType]
+    ...
+  } yield result
+
+After:
+
+  for {
+    x = someStatementHere
+    ...
+  } yield result */
+  } yield i + j + k
 }

--- a/output/src/main/scala-3/fix/NoUnnecessaryPure.scala
+++ b/output/src/main/scala-3/fix/NoUnnecessaryPure.scala
@@ -8,5 +8,6 @@ object NoUnnecessaryPure {
   val x = for {
     i <- 1.pure[Option]
     j = 2
-  } yield i + j
+    k <- 3.pure[Option]
+  } yield i + j + k
 }

--- a/rules/src/main/scala/fix/NoUnnecessaryPure.scala
+++ b/rules/src/main/scala/fix/NoUnnecessaryPure.scala
@@ -20,7 +20,7 @@ case class UnnecessaryPureLint(position: Position, color: Boolean) extends Diagn
   private val red = withColor(AnsiColor.RED)
 
   override def message = s"""|
-    |The first statement of a ${magenta("for")} comprehension no longer needs to use `<-` along with `.pure`, it can use `=`
+    |Statements in a ${magenta("for")} comprehension do not need to use `<-` along with `.pure`, they can use `=`
     |
     |Before:
     |
@@ -57,7 +57,7 @@ extends SyntacticRule("NoUnnecessaryPure") {
 
   override def fix(implicit doc: SyntacticDocument): Patch =
     doc.tree.collect {
-      case Term.ForYield.After_4_9_9(Term.EnumeratorsBlock(PureGenerator(t) :: _), _) =>
-        Patch.lint(UnnecessaryPureLint(t.pos, config.color))
+      case Term.ForYield.After_4_9_9(Term.EnumeratorsBlock(enums), _) =>
+        enums.collect { case PureGenerator(t) => Patch.lint(UnnecessaryPureLint(t.pos, config.color)) }.asPatch
     }.asPatch
 }


### PR DESCRIPTION
The rule originally only checked the first line of the for comprehension because it was designed with [better fors](https://www.scala-lang.org/api/3.6.3/docs/docs/reference/experimental/better-fors.html) in mind, but we can check for it in every step