### PR TITLE
Rebuild minimal version of scaluzzi `Disable` rule

### DIFF
--- a/input/src/main/scala/fix/Disable.scala
+++ b/input/src/main/scala/fix/Disable.scala
@@ -1,0 +1,25 @@
+/*
+rules = Disable
+Disable.symbols = [
+  {
+    id = "javaURL"
+    pattern = "^\\Qjava/net/URL#\\E.*$"
+    message = "URL talks to the network for equality, prefer URI"
+  }
+  {
+    id = "get"
+    pattern = "^scala/(util/Try|Option|None|Some)#get\\(\\)\\.$"
+    message = "this throws runtime exceptions, prefer methods that return an Option"
+  }
+]
+*/
+
+object Disable {
+  val conn = new java.net.URI("http://localhost").toURL.openConnection/* assert: Disable.javaURL
+                                                        ^^^^^^^^^^^^^^
+  URL talks to the network for equality, prefer URI */
+
+  val optionGet = Option(123).get/* assert: Disable.get
+                              ^^^
+  this throws runtime exceptions, prefer methods that return an Option */
+}

--- a/output/src/main/scala/fix/Disable.scala
+++ b/output/src/main/scala/fix/Disable.scala
@@ -1,0 +1,5 @@
+object Disable {
+  val conn = new java.net.URI("http://localhost").toURL.openConnection
+
+  val optionGet = Option(123).get
+}

--- a/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
+++ b/rules/src/main/resources/META-INF/services/scalafix.v1.Rule
@@ -1,3 +1,4 @@
+fix.Disable
 fix.DisableConstructor
 fix.GivenUsing
 fix.MapGetOrElse

--- a/rules/src/main/scala/fix/Disable.scala
+++ b/rules/src/main/scala/fix/Disable.scala
@@ -1,0 +1,36 @@
+package fix
+
+import java.util.regex.Pattern
+import metaconfig.{ConfDecoder, Configured}
+import metaconfig.generic.{deriveDecoder, deriveSurface, Surface}
+import scalafix.config.CustomMessage
+import scalafix.internal.config.ScalafixMetaconfigReaders._
+import scalafix.v1._
+import scala.meta._
+
+case class DisableConfig(symbols: List[CustomMessage[Pattern]])
+
+object DisableConfig {
+  lazy val default: DisableConfig = DisableConfig(Nil)
+
+  implicit val surface: Surface[DisableConfig] = deriveSurface
+  implicit val decoder: ConfDecoder[DisableConfig] = deriveDecoder(default)
+}
+
+case class DisableLint(position: Position, symbol: CustomMessage[Pattern]) extends Diagnostic {
+  final val message = symbol.message.getOrElse(s"${symbol.value} is disabled")
+  override final val categoryID = symbol.id.getOrElse(super.categoryID)
+}
+
+class Disable(config: DisableConfig) extends SemanticRule("Disable") {
+  def this() = this(DisableConfig.default)
+
+  override def withConfiguration(config: Configuration): Configured[Rule] =
+    config.conf.getOrElse("Disable")(this.config).map(new Disable(_))
+
+  override def fix(implicit doc: SemanticDocument): Patch =
+    doc.tree.collect {
+      case t: Name =>
+        config.symbols.filter(_.value.matcher(t.symbol.toString).matches).map(sym => Patch.lint(DisableLint(t.pos, sym)))
+    }.flatten.asPatch
+}


### PR DESCRIPTION
The [scaluzzi `Disable` rule](https://github.com/vovapolu/scaluzzi/blob/master/scalafix/rules/src/main/scala/scalafix/internal/scaluzzi/Disable.scala) doesn't work on scalafix 0.14.7, this rebuilds a minimal version of it